### PR TITLE
Add missing typedef keyword and solve unused variable warning.

### DIFF
--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -36,7 +36,7 @@ typedef enum {
 } esp_image_spi_mode_t;
 
 /* SPI flash clock frequency */
-enum {
+typedef enum {
     ESP_IMAGE_SPI_SPEED_40M,
     ESP_IMAGE_SPI_SPEED_26M,
     ESP_IMAGE_SPI_SPEED_20M,


### PR DESCRIPTION
Add missing typedef keyword and solve unused variable warning in esp_image_format.h.