### PR TITLE
Allow  pyparsing > 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ setuptools
 pyserial>=3.0
 future>=0.15.2
 cryptography>=2.1.4
-pyparsing>=2.0.3,<2.4.0
+pyparsing>=2.0.3,!=2.4.0


### PR DESCRIPTION
As I understand it, only pyparsing 2.4.0 was problematic. For example I am using 2.4.7 and am not seeing any issues.