### PR TITLE
Backport: fix(bt/bluedroid): fixed potential OOB in AVRCP vendor command composition [CVE-2025-68474]

### DIFF
--- a/components/bt/bluedroid/stack/avrc/avrc_opt.c
+++ b/components/bt/bluedroid/stack/avrc/avrc_opt.c
@@ -48,17 +48,28 @@
 ******************************************************************************/
 static BT_HDR   *avrc_vendor_msg(tAVRC_MSG_VENDOR *p_msg)
 {
-    BT_HDR  *p_cmd;
+    BT_HDR  *p_cmd = NULL;
     UINT8   *p_data;
 
-    assert(p_msg != NULL);
+/*
+  A vendor dependent command consists of at least of:
+  - A BT_HDR, plus
+  - AVCT_MSG_OFFSET, plus
+  - 3 bytes for ctype, subunit_type and op_vendor, plus
+  - 3 bytes for company_id
+*/
+#define AVRC_MIN_VENDOR_CMD_LEN (BT_HDR_SIZE + AVCT_MSG_OFFSET + AVRC_VENDOR_HDR_SIZE)
+
+    if (!p_msg) {
+        return NULL;
+    }
 
 #if AVRC_METADATA_INCLUDED == TRUE
-    assert(AVRC_META_CMD_BUF_SIZE > (AVRC_MIN_CMD_LEN + p_msg->vendor_len));
-    if ((p_cmd = (BT_HDR *) osi_malloc(AVRC_META_CMD_BUF_SIZE)) != NULL)
+    if ((AVRC_META_CMD_BUF_SIZE > AVRC_MIN_VENDOR_CMD_LEN + p_msg->vendor_len) &&
+        ((p_cmd = (BT_HDR *) osi_malloc(AVRC_META_CMD_BUF_SIZE)) != NULL))
 #else
-    assert(AVRC_CMD_BUF_SIZE > (AVRC_MIN_CMD_LEN + p_msg->vendor_len));
-    if ((p_cmd = (BT_HDR *) osi_malloc(AVRC_CMD_BUF_SIZE)) != NULL)
+    if ((AVRC_CMD_BUF_SIZE > (AVRC_MIN_VENDOR_CMD_LEN + p_msg->vendor_len)) &&
+        (p_cmd = (BT_HDR *) osi_malloc(AVRC_CMD_BUF_SIZE)) != NULL)
 #endif
     {
         p_cmd->offset   = AVCT_MSG_OFFSET;


### PR DESCRIPTION
backports espressif/esp-idf 0b0b59f2e19c for CVE-2025-68474 — AVRCP release-build assert bypass (use of `assert` in release mode means the bounds check is compiled out; this replaces it with a runtime guard).

openvehicles/esp-idf master is on the 2019-era esp-idf layout where this file lives at `components/bt/bluedroid/stack/avrc/avrc_opt.c` (no `host/` subdirectory yet). git auto-detected the rename during cherry-pick and applied the patch cleanly to the renamed location. the vulnerable pattern is still in openvehicles master.

upstream commit: https://github.com/espressif/esp-idf/commit/0b0b59f2e19c
CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-68474

diff: `components/bt/bluedroid/stack/avrc/avrc_opt.c | +17 -6`

haven't run tests against an openvehicles build.